### PR TITLE
Sleep widget actions

### DIFF
--- a/sass/blocks/left-menu.sass
+++ b/sass/blocks/left-menu.sass
@@ -8,7 +8,7 @@
 
 .page-header>header
   display: flex
-  margin-bottom: 80px
+  margin-bottom: 40px
   position: relative
 
 .page-header>header>div

--- a/sass/blocks/main.sass
+++ b/sass/blocks/main.sass
@@ -23,3 +23,4 @@
 
 @import '../elements/sleep-block'
 @import '../elements/water-info'
+@import '../elements/today-widget'

--- a/sass/elements/dropdown.sass
+++ b/sass/elements/dropdown.sass
@@ -7,7 +7,7 @@
   min-width: 120px
   position: absolute
   top: 15px
-  right: 20%
+  right: 18%
   width: fit-content
 
 .dropdown header p

--- a/sass/elements/sleep-block.sass
+++ b/sass/elements/sleep-block.sass
@@ -1,9 +1,9 @@
 .sleep-widget
   border-radius: 20px
   box-shadow: $black-shadow
-  margin: 40px
+  margin: 20px
   padding-bottom: 20px
-  width: 25%
+  width: 26%
 
 .sleep-widget header
   align-items: flex-start

--- a/sass/elements/sleep-block.sass
+++ b/sass/elements/sleep-block.sass
@@ -19,9 +19,6 @@
 .sleep-widget main
   text-align: center
 
-.weekly-show
-  display: none
-
 .stars
   display: flex
   justify-content: center
@@ -34,16 +31,18 @@
 .stars p
   margin-left: 8px
 
-.weekly-show .date
+.sleep-widget .date
+  display: none
   font-weight: 400
   margin-top: 10px
 
-.weekly-show footer
-  display: flex
+.sleep-widget footer
+  display: none
   justify-content: center
-  padding-top: 25px
+  padding-top: 20px
 
-.weekly-show footer img
+.sleep-widget footer img
   cursor: pointer
-  margin-right: 5px
+  display: inline
+  margin-right: 2px
   width: 10px

--- a/sass/elements/today-widget.sass
+++ b/sass/elements/today-widget.sass
@@ -1,0 +1,17 @@
+.today-widget
+  align-items: center
+  border-radius: 20px
+  box-shadow: $black-shadow
+  display: flex
+  justify-content: space-between
+  margin: 20px
+  padding: 10px 15px
+  width: 26%
+
+.today-widget h1
+  margin-right: 25px
+
+.month
+  color: $numbers-color
+  font-size: 34px
+  font-weight: 300

--- a/sass/layout/_base.sass
+++ b/sass/layout/_base.sass
@@ -25,5 +25,5 @@ h4
 
 .section__number
   color: $numbers-color
-  font-size: 68px
+  font-size: 64px
   font-weight: 700

--- a/src/Sleep.js
+++ b/src/Sleep.js
@@ -1,20 +1,47 @@
 class Sleep {
   constructor(userRepo) {
     this.userID = userRepo.currentUserId;
-    this.date = userRepo.day || null;
+    this.date = userRepo.day;
     this.hoursSlept = null;
     this.sleepQuality = null;
   }
 
-  updateInfo(userRepo) {
-    if (this.date) {
-      const sleep = userRepo.sleepUsersData.find(data => data.userID === this.userID && data.date === this.date);
-      this.hoursSlept = sleep.hoursSlept;
-      this.sleepQuality = sleep.sleepQuality;
+  changeDate(userRepo, day) {
+    if (!day) {
+      this.date = userRepo.day;
+      this.updateInfo(userRepo);
+    } else if (day === 'All day') {
+      this.date = userRepo.day;
+      this.hoursSlept = this.calculateDayAverageInfo(userRepo, 'hours');
+      this.sleepQuality = this.calculateDayAverageInfo(userRepo, 'quality');
+    } else {
+      this.date = day;
+      this.updateInfo(userRepo);
     }
   }
 
-  getWeekFullInfo(userRepo, info) {
+  updateInfo(userRepo) {
+    const sleep = userRepo.sleepUsersData.find(data => data.userID === this.userID && data.date === this.date);
+    if (sleep) {
+      this.hoursSlept = sleep.hoursSlept;
+      this.sleepQuality = sleep.sleepQuality;
+    } else {
+      this.hoursSlept = 0;
+      this.sleepQuality = 0;
+    }
+  }
+
+  splitQuality(quality) {
+    if (quality) {
+      const parts = quality.toString().split('.').map((part) => parseInt(part));
+      return parts;
+    } else {
+      const parts = this.sleepQuality.toString().split('.').map((part) => parseInt(part));
+      return parts;
+    }
+  }
+
+  getWeekFullInfo(userRepo) {
     const week = userRepo.getWeekDates(this.date);
     return userRepo.sleepUsersData.filter((data) => data.userID === this.userID && week.includes(data.date))
   }
@@ -44,4 +71,4 @@ class Sleep {
   }
 }
 
-// module.exports = Sleep;
+module.exports = Sleep;

--- a/src/index.html
+++ b/src/index.html
@@ -67,7 +67,7 @@
       <p>Log in to see your board</p>
     </main>
     <main class="content board">
-      <!-- <section class="water-widget widget">
+      <section class="water-widget widget">
         <header>
           <h1>Hydration</h1>
           <section class="dropdown">
@@ -88,7 +88,7 @@
           <p class="section__number current-hydro">83</p>
           <h2>Ounces</h2>
         </main>
-      </section> -->
+      </section>
       <section class="sleep-widget widget" data-type="sleep">
         <header>
           <h1>Sleep</h1>

--- a/src/index.html
+++ b/src/index.html
@@ -128,13 +128,12 @@
             <img src="../images/circle.svg" data-index="3" >
             <img src="../images/circle.svg" data-index="4" >
             <img src="../images/circle.svg" data-index="5" >
-            <img src="../images/circle-clicked.svg" data-index="6" >
+            <img class="last" src="../images/circle-clicked.svg" data-index="6" >
           </footer>
         </main>
       </section>
     </main>
     <script type="text/javascript" src="../libs/jquery-3.4.1.min.js" charset="utf-8"></script>
-    <script type="text/javascript" src="./dd_search.js"></script>
     <script type="text/javascript" src="../data/users.js"></script>
     <script type="text/javascript" src="../data/hydration.js"></script>
     <script type="text/javascript" src="../data/sleep.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -67,7 +67,7 @@
       <p>Log in to see your board</p>
     </main>
     <main class="content board">
-      <section class="water-widget">
+      <!-- <section class="water-widget widget">
         <header>
           <h1>Hydration</h1>
           <section class="dropdown">
@@ -88,8 +88,8 @@
           <p class="section__number current-hydro">83</p>
           <h2>Ounces</h2>
         </main>
-      </section>
-      <section class="sleep-widget">
+      </section> -->
+      <section class="sleep-widget widget" data-type="sleep">
         <header>
           <h1>Sleep</h1>
           <section class="dropdown">
@@ -108,39 +108,27 @@
           </section>
         </header>
         <main class="dayly-show">
-          <p class="section__number">12000</p>
-          <h2>Hours</h2>
-          <div class="stars">
-            <img src="../images/star-empty.svg" alt="">
-            <img src="../images/star-empty.svg" alt="">
-            <img src="../images/star-empty.svg" alt="">
-            <img src="../images/star-empty.svg" alt="">
-            <img src="../images/star-empty.svg" alt="">
-            <p>5.1</p>
-          </div>
-        </main>
-        <main class="weekly-show">
           <div class="date-choosen">
             <h3 class="date">1999/12/23</h3>
           </div>
           <p class="section__number">12000</p>
           <h2>Hours</h2>
           <div class="stars">
-            <img src="../images/star-empty.svg" alt="">
-            <img src="../images/star-empty.svg" alt="">
-            <img src="../images/star-empty.svg" alt="">
-            <img src="../images/star-empty.svg" alt="">
-            <img src="../images/star-empty.svg" alt="">
+            <img src="../images/star-empty.svg">
+            <img src="../images/star-empty.svg" >
+            <img src="../images/star-empty.svg" >
+            <img src="../images/star-empty.svg" >
+            <img src="../images/star-empty.svg" >
             <p></p>
           </div>
           <footer>
-            <img id="1" src="../images/circle.svg" alt="">
-            <img id="2" src="../images/circle.svg" alt="">
-            <img id="3" src="../images/circle.svg" alt="">
-            <img id="4" src="../images/circle.svg" alt="">
-            <img id="5" src="../images/circle.svg" alt="">
-            <img id="6" src="../images/circle.svg" alt="">
-            <img id="7" src="../images/circle-clicked.svg" alt="">
+            <img src="../images/circle.svg" data-index="0" >
+            <img src="../images/circle.svg" data-index="1" >
+            <img src="../images/circle.svg" data-index="2" >
+            <img src="../images/circle.svg" data-index="3" >
+            <img src="../images/circle.svg" data-index="4" >
+            <img src="../images/circle.svg" data-index="5" >
+            <img src="../images/circle-clicked.svg" data-index="6" >
           </footer>
         </main>
       </section>

--- a/src/index.html
+++ b/src/index.html
@@ -67,6 +67,11 @@
       <p>Log in to see your board</p>
     </main>
     <main class="content board">
+      <section class="today-widget">
+        <h1>Today</h1>
+        <p class="month">Sen</p>
+        <p class="section__number">22</p>
+      </section>
       <section class="water-widget widget">
         <header>
           <h1>Hydration</h1>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -4,9 +4,11 @@ const data = {
   sleep: sleepData,
   activity: activityData
 }
-let userRepository = new UserRepository(data);
+
+const userRepository = new UserRepository(data);
 userRepository.findToday();
 let user;
+let sleep;
 
 $(document).ready(function() {
 
@@ -17,7 +19,8 @@ $(document).ready(function() {
     $('.login-header, .page-header, .empty-board, .board').fadeToggle(100);
     fillUserInfo();
     getFriends(user.findFriends(userRepository));
-    showHydration()
+    showHydration();
+    showSleep();
   });
 
   $('.bio-info').on('click', function () {
@@ -53,4 +56,122 @@ $(document).ready(function() {
     })
     $('.current-hydro').text(currentHydration.numOunces)
   }
+
+  function showSleep() {
+    sleep = new Sleep(userRepository);
+    sleep.changeDate(userRepository);
+    updateSleep();
+  }
+
+  function updateSleep() {
+    let $hours = sleep.hoursSlept;
+    let $quality = sleep.splitQuality();
+    $('.sleep-widget main').children('p').text($hours);
+    if ($quality[0] !== 0) {
+      setQuality($quality)
+    } else {
+      $('.stars img').attr('src', '../images/star-empty.svg');
+      $('.stars p').text($quality.join('.'))
+    }
+  }
+
+  function setQuality(quality) {
+    let $star = $('.stars').children(`img:nth-child(${quality[0]})`);
+    $star.siblings('p').text(quality.join('.'))
+    $star.prevAll().attr('src', '../images/star-full.svg');
+    $star.attr('src', '../images/star-full.svg');
+    if (quality[1] < 5) {
+      $star.next().attr('src', '../images/star-halfless.svg');
+      $star.next().nextAll().attr('src', '../images/star-empty.svg');
+    }
+    if (quality[1] > 5) {
+      $star.next().attr('src', '../images/star-halfmore.svg');
+      $star.next().nextAll().attr('src', '../images/star-empty.svg');
+    }
+    if (quality[1] === 5) {
+      $star.next().attr('src', '../images/star-half.svg');
+      $star.next().nextAll().attr('src', '../images/star-empty.svg');
+    }
+    if (!quality[1]) {
+      $star.next().nextAll().attr('src', '../images/star-empty.svg');
+    }
+  }
+
+  // WEEK DAYS SWITCHER
+  $('.dayly-show footer img').on('click', function() {
+    const $widgetType = $(this).closest('.widget').attr('data-type');
+    const $dayIndex = parseInt($(this).attr('data-index'));
+    $(this).attr('src', '../images/circle-clicked.svg').siblings().attr('src', '../images/circle.svg');
+    if ($widgetType === 'sleep') updateWeekDay(this, $dayIndex);
+  });
+
+  function updateWeekDay(target, index) {
+    const $weekInfo = sleep.getWeekFullInfo(userRepository);
+    let $qualities = sleep.getWeeklyInfo(userRepository, 'quality');
+    $(target).closest('.widget').find('.date').text($weekInfo[index].date);
+    $(target).closest('.widget').find('.section__number').text($weekInfo[index].hoursSlept);
+    const $quality = sleep.splitQuality($qualities[index]);
+    setQuality($quality);
+  }
+
+  // DROPDOWN MENU SCRIPTS
+  $('.dropdown header').on('click', function() {
+    $(this).siblings('div').toggle();
+  });
+
+  $('.dropdown div p').on('click', function() {
+    $(this).parent().siblings('header').children('p').text($(this).text());
+    $(this).parent().siblings('input').val($(this).text());
+    $(this).parent().hide();
+    $(this).closest('.widget').find('footer .last').attr('src', '../images/circle-clicked.svg').siblings().attr('src', '../images/circle.svg');
+    const $widgetType = $(this).closest('.widget').attr('data-type');
+    const $dayEntered = $(this).parent().siblings('input').val();
+
+    if ($dayEntered === 'Week') {
+      $(this).closest('.widget').find('.date, footer').show();
+      $(this).closest('.widget').find('.date').text(sleep.date);
+      sleep.updateInfo(userRepository);
+      updateSleep();
+    }
+
+    if ($dayEntered === 'Today') {
+      $(this).closest('.widget').find('.date, footer').hide();
+      if ($widgetType === 'sleep') {
+        sleep.changeDate(userRepository);
+        updateSleep();
+      };
+    }
+
+    if ($dayEntered === 'All time') {
+      $(this).closest('.widget').find('.date, footer').hide();
+      if ($widgetType === 'sleep') {
+        sleep.changeDate(userRepository, 'All day');
+        updateSleep();
+      };
+    }
+  });
+
+  $('.search label').on('click', function() {
+    $(this).parent().children().toggle();
+    $(this).parent().siblings('.dropdown').toggle();
+  });
+
+  $('.search button').on('click', function() {
+    const $widgetType = $(this).closest('.widget').attr('data-type');
+    const $dayEntered = $(this).siblings('input').val();
+    const $dateVal = /^\d{1,4}\/\d{1,2}\/\d{1,2}$/
+    const $dropdown = $(this).parent().siblings('.dropdown');
+    $(this).parent().children().toggle();
+    $dropdown.toggle();
+    $(this).closest('.widget').find('.date, footer').hide();
+    if ($dateVal.test($dayEntered)) {
+      $dropdown.children('header').children('p').text($dayEntered);
+      $dropdown.children('input').text($dayEntered);
+
+      if ($widgetType === 'sleep') {
+        sleep.changeDate(userRepository, $dayEntered);
+        updateSleep();
+      };
+    }
+  });
 });

--- a/test/sleep-test.js
+++ b/test/sleep-test.js
@@ -36,7 +36,7 @@ describe("Sleep", () => {
     expect(sleep.userID).to.equal(2);
   });
 
-  it("should can keep current day", () => {
+  it("should can keep date information", () => {
     expect(sleep.date).to.equal('2019/09/22');
   });
 
@@ -48,23 +48,81 @@ describe("Sleep", () => {
     expect(sleep.sleepQuality).to.equal(null);
   });
 
-  it("should update sleep hours", () => {
+  it("should can update sleep hours", () => {
     sleep.updateInfo(userRepo);
     expect(sleep.hoursSlept).to.equal(5.1);
   });
 
-  it("should update sleep quality", () => {
+  it("should can update sleep quality", () => {
     sleep.updateInfo(userRepo);
     expect(sleep.sleepQuality).to.equal(4.6);
   });
 
-  it("should get sleep hours for week", () => {
-    expect(sleep.getWeeklyInfo(userRepo, 'hours')).to.deep.equal([7.4,9.5,4.8,10.6,8.5,8.2,5.1]);
+  it("should can show parts of sleep quality", () => {
+    sleep.updateInfo(userRepo);
+    expect(sleep.splitQuality()).to.deep.equal([4,6]);
   });
 
-  it("should get sleep quality for week", () => {
-    expect(sleep.getWeeklyInfo(userRepo, 'quality')).to.deep.equal([2.7,1.7,3.8,1.6,4.3,1.9,4.6]);
+  describe("changeDate method", () => {
+    it("should show today if date's not given", () => {
+      sleep.changeDate(userRepo);
+      expect(sleep.date).to.equal('2019/09/22');
+    });
+
+    it("should change date if date is given", () => {
+      sleep.changeDate(userRepo, '2019/07/01');
+      expect(sleep.date).to.equal('2019/07/01');
+    });
+
+    it("should get sleep hours if date is given", () => {
+      sleep.changeDate(userRepo, '2019/07/01');
+      expect(sleep.date).to.equal('2019/07/01');
+    });
+
+    it("should update sleep hours for given date", () => {
+      sleep.changeDate(userRepo, '2019/07/01');
+      expect(sleep.hoursSlept).to.equal(9);
+    });
+
+    it("should update sleep quality for given date", () => {
+      sleep.changeDate(userRepo, '2019/07/01');
+      expect(sleep.sleepQuality).to.equal(4.7);
+    });
+
+    it("should show no sleep hours if date is not found in database", () => {
+      sleep.changeDate(userRepo, '2011/07/01');
+      expect(sleep.hoursSlept).to.equal(0);
+    });
+
+    it("should show no sleep quality if date is not found in database", () => {
+      sleep.changeDate(userRepo, '2011/07/01');
+      expect(sleep.sleepQuality).to.equal(0);
+    });
   });
+
+  describe('getWeeklyInfo method', () => {
+    it("should get sleep hours for current week", () => {
+      const weekHours = sleep.getWeeklyInfo(userRepo, 'hours');
+      expect(weekHours).to.deep.equal([7.4, 9.5, 4.8, 10.6, 8.5, 8.2, 5.1]);
+    });
+
+    it("should get sleep quality for current week", () => {
+      const weekQuality = sleep.getWeeklyInfo(userRepo, 'quality');
+      expect(weekQuality).to.deep.equal([2.7, 1.7, 3.8, 1.6, 4.3, 1.9, 4.6]);
+    });
+
+    it("should get sleep hours for any week", () => {
+      sleep.changeDate(userRepo, '2019/07/21');
+      const weekHours = sleep.getWeeklyInfo(userRepo, 'hours');
+      expect(weekHours).to.deep.equal([9.3, 8.7, 5.2, 5.1, 6.8, 4.7, 9.5]);
+    });
+
+    it("should get sleep quality for any week", () => {
+      sleep.changeDate(userRepo, '2019/07/21');
+      const weekQuality = sleep.getWeeklyInfo(userRepo, 'quality');
+      expect(weekQuality).to.deep.equal([4.6, 2.2, 2.1, 1.4, 3.1, 3.6, 5]);
+    });
+  })
 
   it("should get day average sleep hours for week", () => {
     expect(sleep.calculateDayAverageInfo(userRepo, 'hours')).to.equal(7.7);


### PR DESCRIPTION
I finally ended sleep widget functionality for showing sleep information. Now when board is first time launched, sleep widget shows today information. User can chose type of showing: daily, weekly or average. When user entered custom date, app checks is it  appropriate format or not. If it's right, app shows all sleep info for this date, only when this date existing in data base, otherwise it shows zeros. 
In addition I moved scripts for data chooser to main JS file, and added changing actions for each buttons. Now this scripts is reusable for every widget.